### PR TITLE
Fix issues to allow requests against API v4

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ dkpn = '296-6501-1-ND'
 part = digikey.product_details(dkpn)
 
 # Search for parts
-search_request = KeywordSearchRequest(keywords='CRCW080510K0FKEA', limit=10, offset = 0)
+search_request = KeywordRequest(keywords='CRCW080510K0FKEA', limit=10, offset = 0)
 result = digikey.keyword_search(body=search_request)
 
 # Only if BatchProductDetails endpoint is explicitly enabled

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,8 @@ setuptools.setup(
         'retrying>=1.3.3',
         'inflection>=0.3.1',
         'certauth>=1.3.0',
-        'urllib3>=1.25.3'
+        'urllib3>=1.25.3',
+        'setuptools>=80.9.0'
     ],
     tests_requires=['pytest>=5.1.2'],
 )


### PR DESCRIPTION
There were two issues preventing usage of the example in the README:
 - distutils.strtobool was called but setuptools was missing from the dependencies
 - KeywordSearchRequest was renamed to KeywordRequest for v4 but the Readme still used KeywordSearchRequest

This pull request fixes both issues and allows running the example from the readme.